### PR TITLE
Fix import syntax of module render_R

### DIFF
--- a/doc/_dvlpt/pycropml.render_r.rst
+++ b/doc/_dvlpt/pycropml.render_r.rst
@@ -1,7 +1,7 @@
 pycropml.render\_r module
 =========================
 
-.. automodule:: pycropml.render_r
+.. automodule:: pycropml.render_R
    :members:
    :undoc-members:
    :show-inheritance:

--- a/doc/_dvlpt/pycropml.rst
+++ b/doc/_dvlpt/pycropml.rst
@@ -43,7 +43,7 @@ Submodules
    pycropml.render_notebook_csharp
    pycropml.render_notebook_java
    pycropml.render_python
-   pycropml.render_r
+   pycropml.render_R
    pycropml.test_generator
    pycropml.topology
    pycropml.unitparser

--- a/src/pycropml/test_generator.py
+++ b/src/pycropml/test_generator.py
@@ -2,7 +2,7 @@ from pycropml import render_fortran
 from pycropml import render_java
 from pycropml import render_csharp
 from pycropml import render_cpp
-from pycropml import render_r
+from pycropml import render_R
 from pycropml.render_cyml import transf
 import six
 
@@ -131,7 +131,7 @@ def generate_test_cpp(model,directory=None):
     return [render_cpp.Model2Package(model, directory).generate_test(model)]
 
 def generate_test_r(model,dir):
-    return [render_r.Model2Package(model, dir).generate_test(model)]
+    return [render_R.Model2Package(model, dir).generate_test(model)]
 
 def generate_test_simplace(model,dir=None):
     pass


### PR DESCRIPTION
Fix import error when generating test : module "render_R" was misnamed "render_r"