### PR TITLE
Issue240

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -22,7 +22,7 @@ requirements:
   run:
     - python {{PY_VER}}
     - antlr4-python3-runtime  ==4.8
-    - cython
+    - cython ==0.29.21
     - xmlformatter
     - path
     - numpy ==1.16.6

--- a/src/pycropml/cyml.py
+++ b/src/pycropml/cyml.py
@@ -5,6 +5,7 @@ Created on Tue Mar 19 22:59:23 2019
 @author: midingoy
 """
 import os
+from os.path import isdir
 from path import Path
 import pycropml
 from pycropml.transpiler.main import Main
@@ -72,15 +73,15 @@ def transpile_package(package, language):
     dir_doc = Path(os.path.join(pkg, 'doc'))
 
     # Generate packages if the directories does not exists.
-    if not output.isdir():
+    if not isdir(output):
         output.mkdir()
-    if not dir_test.isdir():
+    if not isdir(dir_test):
         dir_test.mkdir()
-    if not dir_doc.isdir():
+    if not isdir(dir_doc):
         dir_doc.mkdir()
         
     dir_images = Path(os.path.join(dir_doc, 'images'))
-    if not dir_images.isdir():
+    if not isdir(dir_images):
         dir_images.mkdir()
 
     m2p = render_cyml.Model2Package(models, dir=output)
@@ -88,15 +89,15 @@ def transpile_package(package, language):
     tg_rep1 = Path(os.path.join(output, language))  # target language models  directory in output
     dir_test_lang = Path(os.path.join(dir_test, language))
     
-    if not tg_rep1.isdir():
+    if not isdir(tg_rep1):
         tg_rep1.mkdir()
     
     namep_ = namep.replace("-", "_")    
     tg_rep = Path(os.path.join(tg_rep1, namep_))
-    if not tg_rep.isdir():
+    if not isdir(tg_rep):
         tg_rep.mkdir()
 
-    if not dir_test_lang.isdir():  #Create if it doesn't exist
+    if not isdir(dir_test_lang):  #Create if it doesn't exist
         dir_test_lang.mkdir()
 
     m2p.write_tests()

--- a/src/pycropml/render_cyml.py
+++ b/src/pycropml/render_cyml.py
@@ -5,14 +5,15 @@ Problems:
 """
 from __future__ import print_function
 from __future__ import absolute_import
-from path import Path
-from datetime import datetime
 import os.path
-from pycropml.modelunit import ModelUnit
+from os.path import isdir
+import sys
+from path import Path
 import six
 import shutil
+from datetime import datetime
+from pycropml.modelunit import ModelUnit
 from . import error
-import sys
 
 DATATYPE = {}
 DATATYPE['INT'] = "int"
@@ -63,7 +64,7 @@ class Model2Package(object):
         # Create a directory (mymodel)
         
         directory = Path(os.path.join(self.cwd, 'pyx'))
-        if directory.isdir():
+        if isdir(directory):
             self.dir = directory
         else:
             self.dir = directory.mkdir()
@@ -335,7 +336,7 @@ class Model2Package(object):
         TODO: Manage several models rather than just one.
         """
         self.rep = Path(os.path.join(self.rep, 'test', 'pyx'))
-        if not self.rep.isdir():
+        if not isdir(self.rep):
             self.rep.mkdir()
         files = []
         count = 0

--- a/src/pycropml/render_notebook.py
+++ b/src/pycropml/render_notebook.py
@@ -7,13 +7,15 @@ Problems:
 """
 from __future__ import print_function
 from __future__ import absolute_import
+import six
+import os
+from os.path import isdir
 from path import Path
 
 # The package used to generate Notebook
 import nbformat as nbf
 
 from . import render_python as rp
-import six
 
 
 
@@ -48,7 +50,7 @@ class Model2Nb(rp.Model2Package):
         # Create a directory (mymodel)
         cwd = Path(self.dir)
         directory=cwd/'python_notebook'
-        if (directory).isdir() :
+        if isdir(directory):
             _dir = directory
         else:
             _dir = directory.mkdir()

--- a/src/pycropml/render_notebook_csharp.py
+++ b/src/pycropml/render_notebook_csharp.py
@@ -8,6 +8,8 @@ Problems:
 """
 from __future__ import print_function
 from __future__ import absolute_import
+import os
+from os.path import isdir
 from path import Path
 
 # The package used to generate Notebook
@@ -51,7 +53,7 @@ class Model2Nb(rp.Model2Package):
         # Create a directory (mymodel)
         cwd = Path(self.dir)
         directory=cwd/'csharp_notebook'
-        if (directory).isdir() :
+        if isdir(directory):
             _dir = directory
         else:
             _dir = directory.mkdir()

--- a/src/pycropml/render_notebook_java.py
+++ b/src/pycropml/render_notebook_java.py
@@ -8,6 +8,8 @@ Problems:
 """
 from __future__ import print_function
 from __future__ import absolute_import
+import os
+from os.path import isdir
 from path import Path
 
 # The package used to generate Notebook
@@ -48,7 +50,7 @@ class Model2Nb(rp.Model2Package):
         # Create a directory (mymodel)
         cwd = Path(self.dir)
         directory=cwd/'java_notebook'
-        if (directory).isdir() :
+        if isdir(directory):
             _dir = directory
         else:
             _dir = directory.mkdir()

--- a/src/pycropml/render_python.py
+++ b/src/pycropml/render_python.py
@@ -8,11 +8,12 @@ Problems:
 """
 from __future__ import print_function
 from __future__ import absolute_import
+import os.path
+from os.path import isdir
+import six
+from datetime import datetime
 from path import Path
 import numpy
-from datetime import datetime
-import os.path
-import six
 
 try:
     from openalea.core import interface as inter
@@ -78,7 +79,7 @@ class Model2Package(object):
         # Create a directory (mymodel)
         cwd = Path(self.dir)
         directory=cwd/'python_model'
-        if (directory).isdir() :
+        if isdir(directory):
             self.dir = directory
         else:
             self.dir = directory.mkdir()
@@ -458,7 +459,8 @@ def generate_doc(model):
     Institution: %s
     ExtendedDescription: %s
     ShortDescription: %s
-""" %(desc.Title, "-Version: " + model.version +  "  -Time step: " + model.timestep, desc.Authors, desc.Reference, desc.Institution, desc.ExtendedDescription, desc.ShortDescription)
+""" %(desc.Title, "-Version: " + model.version +  "  -Time step: " + model.timestep, 
+      desc.Authors, desc.Reference, desc.Institution, desc.ExtendedDescription, desc.ShortDescription)
 
     code = '\n'
     code += _doc

--- a/src/pycropml/transpiler/antlr_py/bioma/run.py
+++ b/src/pycropml/transpiler/antlr_py/bioma/run.py
@@ -2,8 +2,15 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
-from path import Path
 import os
+from os.path import isdir
+from copy import deepcopy
+from typing import *
+from path import Path
+
+import networkx as nx
+import itertools
+
 from pycropml.transpiler.antlr_py.to_CASG import to_dictASG, to_CASG
 from pycropml.transpiler.antlr_py.bioma.biomaExtraction import BiomaExtraction
 from pycropml.transpiler.pseudo_tree import Node
@@ -13,8 +20,6 @@ from pycropml.transpiler.ast_transform import transform_to_syntax_tree
 from pycropml.transpiler.antlr_py.generateCyml import writeCyml
 from pycropml.transpiler.antlr_py.createXml import Pl2Crop2ml
 from pycropml.transpiler.antlr_py import repowalk
-from copy import deepcopy
-from typing import *
 
 from pycropml.transpiler.antlr_py.csharp.csharp_preprocessing import ExprStatNode, TransformLocal, CheckingInOut, Custom_call, Declarations,Assignment, Member_access, Binary_op, Index, Local
 from pycropml.transpiler.antlr_py.codeExtraction import extraction
@@ -58,19 +63,18 @@ pseudo_type_={
 
 def create_package(output):
     crop2ml_rep = Path(os.path.join(output, 'crop2ml'))
-    if not crop2ml_rep.isdir():
+    if not isdir(crop2ml_rep):
         crop2ml_rep.mkdir()
     algo_rep = Path(os.path.join(crop2ml_rep, 'algo'))
-    if not algo_rep.isdir():
+    if not isdir(algo_rep):
         algo_rep.mkdir()
     cyml_rep = Path(os.path.join(algo_rep, 'pyx'))
-    if not cyml_rep.isdir():
+    if not isdir(cyml_rep):
         cyml_rep.mkdir()
     return crop2ml_rep, cyml_rep    
                 
 
-import networkx as nx
-import itertools
+
 
 def function_dependency(st, f):
     r = [f]

--- a/src/pycropml/transpiler/antlr_py/bioma/run2.py
+++ b/src/pycropml/transpiler/antlr_py/bioma/run2.py
@@ -2,8 +2,14 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
-from path import Path
 import os
+from os.path import isdir
+from path import Path
+from copy import deepcopy
+from typing import *
+
+from collections import defaultdict
+
 from pycropml.transpiler.antlr_py.to_CASG import to_dictASG, to_CASG
 from pycropml.transpiler.antlr_py.bioma.biomaExtraction import BiomaExtraction
 from pycropml.transpiler.pseudo_tree import Node
@@ -13,8 +19,6 @@ from pycropml.transpiler.ast_transform import transform_to_syntax_tree
 from pycropml.transpiler.antlr_py.generateCyml import writeCyml
 from pycropml.transpiler.antlr_py.createXml import Pl2Crop2ml
 from pycropml.transpiler.antlr_py import repowalk
-from copy import deepcopy
-from typing import *
 
 from pycropml.transpiler.antlr_py.csharp.csharp_preprocessing import ExprStatNode, TransformLocal, CheckingInOut, Custom_call, Declarations,Assignment, Member_access, Binary_op, Index, Local
 
@@ -53,13 +57,13 @@ pseudo_type_={
 
 def create_package(output):
     crop2ml_rep = Path(os.path.join(output, 'crop2ml'))
-    if not crop2ml_rep.isdir():
+    if not isdir(crop2ml_rep):
         crop2ml_rep.mkdir()
     algo_rep = Path(os.path.join(crop2ml_rep, 'algo'))
-    if not algo_rep.isdir():
+    if not isdir(algo_rep):
         algo_rep.mkdir()
     cyml_rep = Path(os.path.join(algo_rep, 'pyx'))
-    if not cyml_rep.isdir():
+    if not isdir(cyml_rep):
         cyml_rep.mkdir()
     return crop2ml_rep, cyml_rep    
                 
@@ -108,7 +112,6 @@ def redefine_params(m:Node, var_:Tuple, member_category, inputs, outputs)->List[
 
 
 
-from collections import defaultdict
 
 def inst_dclass(meth):
     params = meth.params

--- a/src/pycropml/transpiler/antlr_py/simplace/run.py
+++ b/src/pycropml/transpiler/antlr_py/simplace/run.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-from path import Path
 import os
+from os.path import isdir
+from path import Path
+
 from pycropml.transpiler.antlr_py.to_CASG import to_CASG, to_dictASG
 from pycropml.transpiler.antlr_py.createXml import Pl2Crop2ml
 from pycropml.transpiler.antlr_py.generateCyml import writeCyml
@@ -14,10 +16,6 @@ from pycropml.transpiler.ast_transform import transform_to_syntax_tree
 from pycropml.transpiler.antlr_py.to_specification import extractcomments
 from pycropml.transpiler.antlr_py.createXml import Pl2Crop2ml, generate_compositefile, generate_unitfile, create_repo
 from pycropml.transpiler.antlr_py.codeExtraction import remove
-
-
-
-
 
 
 def translate(algo, names):
@@ -76,13 +74,13 @@ def run_simplace(components, output):
     simpleStrat= Path(components).glob('*.java')
     compositeStrat = Path(components).glob('*.xml')[0]
     crop2ml_rep = Path(os.path.join(output, 'crop2ml'))
-    if not crop2ml_rep.isdir():
+    if not isdir(crop2ml_rep):
         crop2ml_rep.mkdir()
     algo_rep = Path(os.path.join(crop2ml_rep, 'algo'))
-    if not algo_rep.isdir():
+    if not isdir(algo_rep):
         algo_rep.mkdir()
     cyml_rep = Path(os.path.join(algo_rep, 'pyx'))
-    if not cyml_rep.isdir():
+    if not isdir(cyml_rep):
         cyml_rep.mkdir()
     models = []
     for strat in simpleStrat:

--- a/src/pycropml/transpiler/antlr_py/stics/run.py
+++ b/src/pycropml/transpiler/antlr_py/stics/run.py
@@ -1,6 +1,12 @@
 from __future__ import absolute_import
 from __future__ import print_function
 import os
+#import copy
+from os.path import isdir
+import tempfile
+from path import Path
+from collections import OrderedDict
+
 from pycropml.composition import Description
 from pycropml.transpiler.antlr_py import repowalk
 from pycropml.transpiler.antlr_py.to_CASG import to_CASG, to_dictASG
@@ -9,16 +15,12 @@ from pycropml.transpiler.ast_transform import transform_to_syntax_tree
 from pycropml.transpiler.antlr_py.generateCyml import writeCyml
 from pycropml.transpiler.antlr_py.fortran import f90_cyml
 from pycropml.transpiler.antlr_py.cmake.cmakeTransformer import retrievefiles
-from collections import OrderedDict
 #from pycropml.transpiler.antlr_py.extraction import ExtractComments  
 from pycropml.transpiler.antlr_py.codeExtraction import extraction
 from pycropml.transpiler.antlr_py.fortran.fortran_preprocessing import Declarations, Attr, Assignment, Call_stmt, Implicit_return, Local
 from pycropml.transpiler.antlr_py.to_specification import extractMetaInfo, createObjectModel, extractcomments, createObjectCompo
 from pycropml.transpiler.antlr_py.createXml import Pl2Crop2ml, generate_compositefile, generate_unitfile, create_repo
-import tempfile
 from pycropml.transpiler.antlr_py.extract_metadata_from_comment import ExtractComments, extract
-import copy
-from path import Path
 
 types = ["float", "str", "list", "array", "int", "boolean"]
 

--- a/src/pycropml/transpiler/antlr_py/tests/test_bioma.py
+++ b/src/pycropml/transpiler/antlr_py/tests/test_bioma.py
@@ -1,8 +1,9 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
-from path import Path
 import os
+from os.path import isdir
+from path import Path
 from pycropml.transpiler.antlr_py.to_CASG import to_dictASG, to_CASG
 from pycropml.transpiler.antlr_py.bioma.biomaExtraction import BiomaExtraction
 from pycropml.transpiler.pseudo_tree import Node
@@ -27,13 +28,13 @@ varInfo = data.glob('*VarInfo.cs')
 
 output = cwd/'examples'/'SiriusComponent'/'phenology'
 crop2ml_rep = Path(os.path.join(output, 'crop2ml'))
-if not crop2ml_rep.isdir():
+if not isdir(crop2ml_rep):
     crop2ml_rep.mkdir()
 algo_rep = Path(os.path.join(crop2ml_rep, 'algo'))
-if not algo_rep.isdir():
+if not isdir(algo_rep):
     algo_rep.mkdir()
 cyml_rep = Path(os.path.join(algo_rep, 'pyx'))
-if not cyml_rep.isdir():
+if not isdir(cyml_rep):
     cyml_rep.mkdir()
 
 


### PR DESCRIPTION
* Set cython version to **0.29.32**
 New version (Cython > 3.0) lead to this error
```python
Traceback (most recent call last):
  File "/Users/pradal/miniforge3/envs/cropml/bin/cyml", line 33, in <module>
    sys.exit(load_entry_point('pycropml', 'console_scripts', 'cyml')())
  File "/Users/pradal/devlp/git/PyCrop2ML/src/pycropml/main.py", line 133, in main
    status = transpile_package(sourcef, language)
  File "/Users/pradal/devlp/git/PyCrop2ML/src/pycropml/cyml.py", line 134, in transpile_package
    test.parse()
  File "/Users/pradal/devlp/git/PyCrop2ML/src/pycropml/transpiler/main.py", line 110, in parse
    self.tree = parser(self.file)
  File "/Users/pradal/devlp/git/PyCrop2ML/src/pycropml/transpiler/Parser.py", line 83, in parser
    tree = context.parse(source_desc, scope, pxd=None, full_module_name=module)
  File "/Users/pradal/miniforge3/envs/cropml/lib/python3.8/site-packages/Cython/Compiler/Main.py", line 375, in parse
    num_errors = Errors.get_errors_count()
  File "/Users/pradal/miniforge3/envs/cropml/lib/python3.8/site-packages/Cython/Compiler/Errors.py", line 300, in get_errors_count
    return threadlocal.cython_errors_count
AttributeError: '_thread._local' object has no attribute 'cython_errors_count'

```

* Update usage of path.isdir : path.isdir has been removed with version 17.0.0
See https://path.readthedocs.io/en/latest/history.html#v17-0-0