### PR TITLE
Change CI branch from main to v0.1.5

### DIFF
--- a/.github/workflows/conda-package-build.yml
+++ b/.github/workflows/conda-package-build.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        os: [ macos-13, windows-latest, ubuntu-latest]
+        os: [ macos-15-intel, windows-latest, ubuntu-latest]
         python-minor-version: [7, 8, 9]
         isMaster:
           - ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/dev') }}
@@ -26,10 +26,10 @@ jobs:
             os: ubuntu-latest
             python-minor-version: 9
           - isMaster: false
-            os: macos-13
+            os: macos-15-intel
             python-minor-version: 8
           - isMaster: false
-            os: macos-13
+            os: macos-15-intel
             python-minor-version: 9
           - isMaster: false
             os: windows-latest


### PR DESCRIPTION
We need to rely on the older version of openalea/action-build-publish-anaconda

The new version has changed drastically